### PR TITLE
Update Sodium support to 0.8.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://fabricmc.net/develop/ for new versions
-    id 'fabric-loom' version '1.14-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.16-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '2.0.116' apply false
 }

--- a/common/src/main/java/de/linusdev/sodiumcoreshadersupport/CommonClass.java
+++ b/common/src/main/java/de/linusdev/sodiumcoreshadersupport/CommonClass.java
@@ -7,7 +7,7 @@ import de.linusdev.sodiumcoreshadersupport.platform.Services;
 import net.minecraft.SharedConstants;
 import net.minecraft.WorldVersion;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.resources.IoSupplier;
@@ -113,7 +113,7 @@ public class CommonClass {
 
 
             // Check if pack has versions info
-            IoSupplier<InputStream> streamSup = res.getResource(PackType.CLIENT_RESOURCES, ResourceLocation.fromNamespaceAndPath("sodiumcoreshadersupport", "versions.json"));
+            IoSupplier<InputStream> streamSup = res.getResource(PackType.CLIENT_RESOURCES, Identifier.fromNamespaceAndPath("sodiumcoreshadersupport", "versions.json"));
 
             if(streamSup == null) {
                 // No info, show warning

--- a/common/src/main/java/de/linusdev/sodiumcoreshadersupport/Constants.java
+++ b/common/src/main/java/de/linusdev/sodiumcoreshadersupport/Constants.java
@@ -1,6 +1,6 @@
 package de.linusdev.sodiumcoreshadersupport;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,5 +11,5 @@ public class Constants {
 	public static final Logger LOG = LoggerFactory.getLogger(MOD_NAME);
 
 	public static final String SODIUM_MOD_ID = "sodium";
-	public static final ResourceLocation RELOAD_LISTENER_ID = ResourceLocation.fromNamespaceAndPath("sodiumcoreshadersupport", "shaderloader");
+	public static final Identifier RELOAD_LISTENER_ID = Identifier.fromNamespaceAndPath("sodiumcoreshadersupport", "shaderloader");
 }

--- a/common/src/main/java/de/linusdev/sodiumcoreshadersupport/mixin/MixinShaderLoader.java
+++ b/common/src/main/java/de/linusdev/sodiumcoreshadersupport/mixin/MixinShaderLoader.java
@@ -5,7 +5,7 @@ import net.caffeinemc.mods.sodium.client.gl.shader.GlShader;
 import net.caffeinemc.mods.sodium.client.gl.shader.ShaderConstants;
 import net.caffeinemc.mods.sodium.client.gl.shader.ShaderLoader;
 import net.caffeinemc.mods.sodium.client.gl.shader.ShaderType;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.apache.commons.io.IOUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -26,7 +26,7 @@ public class MixinShaderLoader {
     @Inject(at = @At("HEAD"), method = "loadShader")
     private static void loadShaderInject(
             ShaderType type,
-            ResourceLocation name,
+            Identifier name,
             ShaderConstants constants, CallbackInfoReturnable<GlShader> cir
     ) {
         LOG.info("Start loading shader in namespace '"  + name.getNamespace() + "': " + name.getPath());
@@ -37,7 +37,7 @@ public class MixinShaderLoader {
      * @reason Load shaders from resources, loaded by then ResourceManager instead of reading them as java resource.
      */
     @Overwrite
-    public static String getShaderSource(ResourceLocation name) {
+    public static String getShaderSource(Identifier name) {
 
         if(shaders == null) {
             // fallback to default getShaderSource

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 # Every field you add must be added to buildSrc/src/main/groovy/multiloader-common.gradle expandProps map.
 
 # Project
-mod_version=1.4.4
+mod_version=1.4.5
 group=de.linusdev
 java_version=21
 archives_base_name=sodiumcoreshadersupport
-mod_changelog=- updated to sodium 0.8.0\n- no neoforge version right now due to compile problems
+mod_changelog=- updated to sodium 0.8.11\n- no neoforge version right now due to compile problems
 
 # Common
 mod_name=Sodium Core Shader Support
@@ -22,10 +22,10 @@ additional_supported_mc_versions=
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.10-20251010.172816
+neo_form_version=1.21.11-20251209.172050
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.10
-parchment_version=2025.10.12
+parchment_minecraft=1.21.11
+parchment_version=2025.12.20
 
 # Fabric
 # check these on https://fabricmc.net/develop
@@ -44,7 +44,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Dependencies
-sodium_version=mc1.21.11-0.8.0
+sodium_version=mc1.21.11-0.8.11
 
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,4 +48,6 @@ plugins {
 rootProject.name = 'Sodium Core Shader Support'
 include('common')
 include('fabric')
-include('neoforge')
+if (!providers.gradleProperty('disable_neoforge').map { it.toBoolean() }.orElse(false).get()) {
+    include('neoforge')
+}


### PR DESCRIPTION
## Summary
- update the Minecraft 1.21.11 Sodium target to 0.8.11
- bump the mod version to 1.4.5 and align common mappings to 1.21.11
- honor the existing disable_neoforge flag for the default build
